### PR TITLE
fix (config.toml): add .streamlit/config.toml to repo root

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,12 @@
+# Theme configuration
+[theme]
+# Base theme ("light" or "dark")
+base="dark"
+# Primary accent color for interactive elements.
+primaryColor="#287C34"
+# Background color for the main content area.
+backgroundColor="#EBFBEB"
+# Background color for sidebar and most interactive widgets.
+secondaryBackgroundColor="#DFF9DE"
+# Color used for almost all text.
+textColor="#000000"

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -5,7 +5,5 @@ pandas
 plotly
 python-dotenv
 numpy
-langsmith
-mlflow
 jinja2
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,9 +1,0 @@
-streamlit
-openai
-psycopg2-binary
-pandas
-plotly
-python-dotenv
-numpy
-jinja2
-setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
`config.toml` :

- Because our app scripts reside in a subdirectory of the repo `streamlit/`, the usual place for `config.toml` is the `streamlit/.streamlit` directory. This works perfectly when the app is deployed locally. However, when deployed in Streamlit Cloud, the `.streamlit` directory must sit in the repo root. Therefore, this same directory now exists, inelegantly, in two locations.