### PR TITLE
fix (config.toml): add .streamlit/config.toml to repo root

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,12 @@
+# Theme configuration
+[theme]
+# Base theme ("light" or "dark")
+base="dark"
+# Primary accent color for interactive elements.
+primaryColor="#287C34"
+# Background color for the main content area.
+backgroundColor="#EBFBEB"
+# Background color for sidebar and most interactive widgets.
+secondaryBackgroundColor="#DFF9DE"
+# Color used for almost all text.
+textColor="#000000"


### PR DESCRIPTION
`config.toml` :

- Because our app scripts reside in a subdirectory of the repo `streamlit/`, the usual place for `config.toml` is the `streamlit/.streamlit` directory. This works perfectly when the app is deployed locally. However, when deployed in Streamlit Cloud, the `.streamlit` directory must sit in the repo root. Therefore, this same directory now exists, inelegantly, in two locations.