### PR TITLE
removing the requried_keys

### DIFF
--- a/streamlit/utils/inference.py
+++ b/streamlit/utils/inference.py
@@ -37,15 +37,6 @@ def run_inference(lesson_plan, prompt_id, llm_model, llm_model_temp,
         dict: Inference result or error response.
     """
     from utils.db_scripts import get_prompt
-    required_keys = ["title", "topic", "subject", "keyStage"]
-    if set(lesson_plan.keys()) == set(required_keys):
-        return {
-            "response": {
-                "result": None, 
-                "justification": "Lesson data is missing for this check."
-            },
-            "status": "ABORTED",
-        }
         
     prompt_details = get_prompt(prompt_id)
     if prompt_details['objective_title'] == "AILA Moderation":


### PR DESCRIPTION
- removing the required_keys to allow us to evaluate lessons that were blocked early for toxicity
- this was only added in the first place because we mistakenly thought these were empty and irrelevant lesson plans